### PR TITLE
fix compilation for higher version of pytorch.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
-torch>=1.10.1
-torchvision>=0.11.2
+torch>=1.12
+torchvision>=0.13
 numpy
 matplotlib
 brewer2mpl
@@ -11,6 +11,7 @@ omegaconf
 tqdm
 future  # tensorboard dependency
 kornia
+cython
 shapely
 scikit-image
 h5py

--- a/third_party/afm_lib/afm_op/cuda/afm.cu
+++ b/third_party/afm_lib/afm_op/cuda/afm.cu
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
+// #include <THC/THC.h>
 #include <THC/THCDeviceUtils.cuh>
 
 #include <vector>
@@ -117,6 +117,7 @@ std::tuple<at::Tensor,at::Tensor> afm_cuda(
     
     // THCudaFree(state, aflabel_dev);
     // THCudaFree(state, afmap_dev);
-    THCudaCheck(cudaGetLastError());
+    // THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return std::make_tuple(afmap, aflabel);
 }


### PR DESCRIPTION
THC/THC.h is removed in the new version of pytorch + cuda 
(refer to https://discuss.pytorch.org/t/question-about-thc-thc-h/147145)

In this pull request the function THCudaCheck() is substituted with the new interface AT_CUDA_CHECK.

Test succeeded with torch 1.11.0+cu113. Maybe it is still needed to test under torch 1.10.0 to see if it works with the minimum required version in the requirements.txt
