### PR TITLE
remove deprecated torch._six string_classes

### DIFF
--- a/deeplsd/utils/tensor.py
+++ b/deeplsd/utils/tensor.py
@@ -1,10 +1,10 @@
 import numpy as np
 from skimage import measure as skmeasure
-from torch._six import string_classes
 import collections.abc as collections
 import torch
 import cv2
 
+string_classes = str
 
 def map_tensor(input_, func):
     if isinstance(input_, torch.Tensor):


### PR DESCRIPTION
Thank you for great research.

for minor bug fix, in the new pytorch version, ._six string_classes is deprecated. (https://github.com/pytorch/pytorch/pull/94709)
changed to `string_classes = str`